### PR TITLE
Reverted to UTF-8, now calling getText() instead of getBytes().

### DIFF
--- a/src/main/groovy/com/appswithlove/loco/LocoTask.groovy
+++ b/src/main/groovy/com/appswithlove/loco/LocoTask.groovy
@@ -38,9 +38,7 @@ class LocoTask extends DefaultTask {
                 doOutput = true
                 requestMethod = 'GET'
 
-                def text = content.text
-                text = new String(text.getBytes("UTF-16"), "UTF-16")
-
+                def text = content.getText("UTF-8")
                 if (project.Loco.placeholderPattern != null) {
                     text = text.replaceAll(project.Loco.placeholderPattern, "%s")
                 }


### PR DESCRIPTION
Since the XML files are downloaded from Loco as UTF-8, that should not be the problem (my mistake). I am wondering if possibly the issue is coming from the call to "getBytes()". This change switches to calling "getText()" directly on the content from online, and returns it as a String, which is then used to create the new file.

#14 