### PR TITLE
Add option to order assets alphabetically by Asset ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Loco {
     hideComments = false // optionally hide comments & loco metadata 
     tags = 'Android, !iOS' // optional, filter assets by comma-separated tag names. Match any tag with `*` and negate tags by prefixing with `!`	 
     fallbackLang = 'en' // optional, fallback language when not present
+    orderByAssetId = false // optionally order assets alphabetically by Asset ID
 }
-
 ```
 
 4.Done! 

--- a/src/main/groovy/com/appswithlove/loco/LocoExtension.groovy
+++ b/src/main/groovy/com/appswithlove/loco/LocoExtension.groovy
@@ -11,4 +11,5 @@ class LocoExtension {
     def hideComments = false
     def tags
     def fallbackLang = null
+    def orderByAssetId = false
 }

--- a/src/main/groovy/com/appswithlove/loco/LocoTask.groovy
+++ b/src/main/groovy/com/appswithlove/loco/LocoTask.groovy
@@ -17,7 +17,7 @@ class LocoTask extends DefaultTask {
     @TaskAction
     void doLast() {
 
-        //Determine whether it should show comments or not
+        // Determine whether it should show comments or not
         def parameter = "?no-comments=${project.Loco.hideComments}"
 
         // Add tags filter
@@ -28,6 +28,11 @@ class LocoTask extends DefaultTask {
         // If a fallback language was specified, include it as a parameter
         if (project.Loco.fallbackLang != null) {
             parameter = parameter + "&fallback=${project.Loco.fallbackLang}"
+        }
+
+        // Determine whether assets should be ordered alphabetically by Asset ID, include parameter if necessary
+        if (project.Loco.orderByAssetId) {
+            parameter = parameter + "&order=id"
         }
 
         for (String lang in project.Loco.lang) {


### PR DESCRIPTION
I personally prefer string IDs in alphabetical order and I've noticed that the Loco API supports it. Maybe someone else has similar needs and would also like to have this option, so I thought I would contribute a little bit.