### PR TITLE
Add alternative indexing

### DIFF
--- a/lib/src/main/groovy/com/appswithlove/loco/LocoConfig.groovy
+++ b/lib/src/main/groovy/com/appswithlove/loco/LocoConfig.groovy
@@ -16,4 +16,5 @@ class LocoConfig {
     def saveDefLangDuplicate = false
     def resourceNamePrefix = null
     def ignoreMissingTranslationWarnings = false
+    def index
 }

--- a/lib/src/main/groovy/com/appswithlove/loco/TaskUtils.groovy
+++ b/lib/src/main/groovy/com/appswithlove/loco/TaskUtils.groovy
@@ -13,6 +13,11 @@ class TaskUtils {
             parameter = parameter + "&filter=${locoConfig.tags}"
         }
 
+        // Add index
+        if (locoConfig.index != null) {
+            parameter = parameter + "&index=${locoConfig.index}"
+        }
+
         // Add status filter
         if (locoConfig.status != null) {
             parameter = parameter + "&status=${locoConfig.status}"


### PR DESCRIPTION
The index parameter allows you to specify an alternative [lookup key](https://localise.biz/help/glossary/lookup-key) for your target file. If you leave this empty Loco will use the right key for the current format. For example, a PO file will be indexed by "text" but Android XML resources will be indexed by "id".