### PR TITLE
Feature: locoPush task to sync local strings to Loco

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If your project relies on an older version of AGP, please stick to plugin versio
 
 It's no longer needed to differentiate between using this plugin for one or multiple Loco configurations.
 
-The Gradle Loco task `updateLoco` will update the Strings for all configs specified inside the plugin.
+The Gradle Loco task `locoFetch` will update the Strings for all configs specified inside the plugin.
 
 ⚠️ The Gradle Loco task `updateLocoMultiple` has been removed ! ⚠️
 
@@ -86,14 +86,14 @@ Loco {
 
 ## Instructions
 
-In oder to use the plugin follow those steps:
+In order to use the plugin follow those steps:
 
 1.Add the following code to you `build.gradle` file in the `root` folder.
 
 ```kotlin
 // Kotlin DSL
 plugins {
-  id("com.appswithlove.loco") version "1.0.0" apply false
+  id("com.appswithlove.loco") version "1.1.0" apply false
 }
 ```
 
@@ -108,7 +108,7 @@ buildscript {
 
     dependencies {
         //…
-        classpath 'com.appswithlove.loco:loco:1.0.0'
+        classpath 'com.appswithlove.loco:loco:1.1.0'
     }
 }
 ```
@@ -163,21 +163,37 @@ Loco {
 
 ## Usage
 
-After installing the plugin, you should be able to find the Gradle Loco tasks in Android Studio.
+The plugin provides two Gradle tasks:
 
-```console 
-"Gradle Project" Window -> Tasks -> Other -> updateLoco
-```
+### `locoFetch` — fetch strings from Loco into the project
 
-Otherwise, you can call the gradle tasks via command:
+Downloads translations from Loco and writes them to the local `strings.xml` files. This overwrites any local changes for the fetched languages.
 
 ```console
-./gradlew updateLoco
+./gradlew locoFetch
 ```
+
+Or find it in Android Studio: `Gradle` → `Tasks` → `other` → `locoFetch`
+
+> `updateLoco` is kept as a deprecated alias for `locoFetch` and will be removed in a future version.
+
+---
+
+### `locoPush` — push local strings to Loco
+
+Reads your local `strings.xml` files and imports them into the Loco project. Only adds new strings — nothing is deleted from Loco.
+
+> ⚠️ **Requires a Full access key** in the Loco project settings (`Developer tools` → `API keys`).
+
+```console
+./gradlew locoPush
+```
+
+Or find it in Android Studio: `Gradle` → `Tasks` → `other` → `locoPush`
 
 ## ⚠️ Keep in mind
 
-Executing `updateLoco` will override all existing `strings.xml` (or other, if custom `fileName`)
+Executing `locoFetch` will override all existing `strings.xml` (or other, if custom `fileName`)
 files of the given `languages`. Any type of app specific text strings should be placed into a
 separate string file, such as `constants.xml`.
 
@@ -212,13 +228,13 @@ Loco {
 After that you can run the same task as you would for a single config:
 
 ```console 
-"Gradle Project" Window -> Tasks -> Other -> updateLoco
+"Gradle Project" Window -> Tasks -> Other -> locoFetch
 ```
 
 or
 
 ```console
-./gradlew updateLoco
+./gradlew locoFetch
 ```
 
 ---
@@ -247,7 +263,7 @@ buildscript {
         // ...
     }
     dependencies {
-        classpath 'com.appswithlove.loco:loco:1.0.0'
+        classpath 'com.appswithlove.loco:loco:1.1.0'
         // ...
     }
 }
@@ -256,7 +272,7 @@ buildscript {
 After that, call the following script in the terminal of your android app (replace `FLAVOUR`)
 
 ```console
-./gradlew updateLoco -Dorg.gradle.debug=true --no-daemon
+./gradlew locoFetch -Dorg.gradle.debug=true --no-daemon
 ```
 
 Lastly, open the Loco Plugin in Android Studio, add an `Remote` build configuration

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.appswithlove.loco
 POM_ARTIFACT_ID=loco
-VERSION_NAME=1.0.0
+VERSION_NAME=1.1.0
 
 POM_NAME=loco-android
 POM_DESCRIPTION=A plugin to synchronize Loco translations with Android project

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ lifecycleRuntimeKtx = "2.9.4"
 maven-publish = "0.34.0"
 gradle-publish = "2.0.0"
 coveralls = "2.4.0"
-loco = "0.4.1"
+loco = "1.0.0"
 junitVersion = "1.3.0"
 junit = "4.13.2"
 

--- a/lib/src/integrationTest/kotlin/com/appswithlove/loco/http/DefaultLocoHttpClientTest.kt
+++ b/lib/src/integrationTest/kotlin/com/appswithlove/loco/http/DefaultLocoHttpClientTest.kt
@@ -2,6 +2,7 @@ package com.appswithlove.loco.http
 
 import com.appswithlove.loco.plugin.LocoConfig
 import com.sun.net.httpserver.HttpServer
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import org.junit.jupiter.api.AfterEach
@@ -13,13 +14,20 @@ class DefaultLocoHttpClientTest {
 
     private lateinit var server: HttpServer
     private var capturedUri: String = ""
+    private var capturedMethod: String = ""
+    private var capturedBody: String = ""
+    private var serverResponse: String = "<resources></resources>"
+
+    private fun importBaseUrl() = "http://localhost:${server.address.port}"
 
     @BeforeEach
     fun setUp() {
         server = HttpServer.create(InetSocketAddress(0), 0)
         server.createContext("/") { exchange ->
             capturedUri = exchange.requestURI.toString()
-            val response = "<resources></resources>".toByteArray()
+            capturedMethod = exchange.requestMethod
+            capturedBody = exchange.requestBody.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            val response = serverResponse.toByteArray()
             exchange.sendResponseHeaders(200, response.size.toLong())
             exchange.responseBody.use { it.write(response) }
         }
@@ -91,5 +99,56 @@ class DefaultLocoHttpClientTest {
         DefaultLocoHttpClient().fetchTranslation(config, "en")
 
         capturedUri shouldContain "status=translated"
+    }
+
+    @Test
+    fun pushTranslationSendsPostRequest() {
+        serverResponse =
+            """{"message":"1 assets imported","locales":[{"progress":{"translated":1,"untranslated":0}}]}"""
+        DefaultLocoHttpClient()
+            .pushTranslation("key", "en", "<resources/>", importBaseUrl())
+
+        capturedMethod shouldBe "POST"
+    }
+
+    @Test
+    fun pushTranslationIncludesLocaleParam() {
+        serverResponse =
+            """{"message":"Nothing updated","locales":[{"progress":{"translated":0,"untranslated":0}}]}"""
+        DefaultLocoHttpClient()
+            .pushTranslation("key", "de", "<resources/>", importBaseUrl())
+
+        capturedUri shouldContain "locale=de"
+    }
+
+    @Test
+    fun pushTranslationIncludesDeleteAbsentParam() {
+        serverResponse =
+            """{"message":"Nothing updated","locales":[{"progress":{"translated":0,"untranslated":0}}]}"""
+        DefaultLocoHttpClient()
+            .pushTranslation("key", "en", "<resources/>", importBaseUrl())
+
+        capturedUri shouldContain "delete-absent=0"
+    }
+
+    @Test
+    fun pushTranslationDoesNotIncludeIgnoreExistingParam() {
+        serverResponse =
+            """{"message":"Nothing updated","locales":[{"progress":{"translated":0,"untranslated":0}}]}"""
+        DefaultLocoHttpClient()
+            .pushTranslation("key", "en", "<resources/>", importBaseUrl())
+
+        capturedUri shouldNotContain "ignore-existing"
+    }
+
+    @Test
+    fun pushTranslationSendsXmlBody() {
+        serverResponse =
+            """{"message":"1 assets imported","locales":[{"progress":{"translated":1,"untranslated":0}}]}"""
+        val xml = "<resources><string name=\"hello\">Hello</string></resources>"
+        DefaultLocoHttpClient()
+            .pushTranslation("key", "en", xml, importBaseUrl())
+
+        capturedBody shouldBe xml
     }
 }

--- a/lib/src/main/kotlin/com/appswithlove/loco/Constants.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/Constants.kt
@@ -3,4 +3,5 @@ package com.appswithlove.loco
 object Constants {
     const val LOCO_EXPORT_LOCALE_URL = "https://localise.biz/api/export/locale"
     const val LOCO_LOCALES_URL = "https://localise.biz/api/locales"
+    const val LOCO_IMPORT_URL = "https://localise.biz/api/import"
 }

--- a/lib/src/main/kotlin/com/appswithlove/loco/dto/PushResultDto.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/dto/PushResultDto.kt
@@ -1,0 +1,21 @@
+package com.appswithlove.loco.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PushResultDto(
+    @SerialName("message") val message: String = "",
+    @SerialName("locales") val locales: List<PushLocaleDto> = emptyList(),
+)
+
+@Serializable
+internal data class PushLocaleDto(
+    @SerialName("progress") val progress: PushProgressDto = PushProgressDto(),
+)
+
+@Serializable
+internal data class PushProgressDto(
+    @SerialName("translated") val translated: Int = 0,
+    @SerialName("untranslated") val untranslated: Int = 0,
+)

--- a/lib/src/main/kotlin/com/appswithlove/loco/http/DefaultLocoHttpClient.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/http/DefaultLocoHttpClient.kt
@@ -44,4 +44,32 @@ internal class DefaultLocoHttpClient : LocoHttpClient {
 
         return connection.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
     }
+
+    override fun pushTranslation(
+        apiKey: String,
+        locale: String,
+        xmlContent: String,
+        importBaseUrl: String,
+    ): String {
+        val bytes = xmlContent.toByteArray(Charsets.UTF_8)
+        val connection =
+            (URL("$importBaseUrl/xml?locale=$locale&delete-absent=0").openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                doOutput = true
+                setRequestProperty("Authorization", "Loco $apiKey")
+                setRequestProperty("Content-Type", "text/xml; charset=utf-8")
+                connectTimeout = 10000
+                readTimeout = 10000
+            }
+        connection.outputStream.use { it.write(bytes) }
+
+        if (connection.responseCode != 200) {
+            val error = (connection.errorStream ?: connection.inputStream)
+                .bufferedReader()
+                .use { it.readText() }
+            throw IllegalStateException("Push failed with code ${connection.responseCode}: $error")
+        }
+
+        return connection.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+    }
 }

--- a/lib/src/main/kotlin/com/appswithlove/loco/http/LocoHttpClient.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/http/LocoHttpClient.kt
@@ -5,4 +5,10 @@ import com.appswithlove.loco.plugin.LocoConfig
 internal interface LocoHttpClient {
     fun fetchLocales(apiKey: String): String
     fun fetchTranslation(locoConfig: LocoConfig, language: String): String
+    fun pushTranslation(
+        apiKey: String,
+        locale: String,
+        xmlContent: String,
+        importBaseUrl: String,
+    ): String
 }

--- a/lib/src/main/kotlin/com/appswithlove/loco/plugin/LocoConfig.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/plugin/LocoConfig.kt
@@ -4,6 +4,7 @@ import com.appswithlove.loco.Constants
 
 class LocoConfig {
     var locoBaseUrl: String = Constants.LOCO_EXPORT_LOCALE_URL
+    var locoImportBaseUrl: String = Constants.LOCO_IMPORT_URL
     var apiKey: String? = null
     var lang: List<String>? = null
     var defLang: String? = null

--- a/lib/src/main/kotlin/com/appswithlove/loco/plugin/LocoFetchTask.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/plugin/LocoFetchTask.kt
@@ -10,10 +10,10 @@ import org.gradle.api.tasks.TaskAction
 /**
  * Task to update from a single loco file
  */
-abstract class LocoTask : DefaultTask() {
+abstract class LocoFetchTask : DefaultTask() {
 
     companion object {
-        const val NAME = "updateLoco"
+        const val NAME = "locoFetch"
     }
 
     @get:Input

--- a/lib/src/main/kotlin/com/appswithlove/loco/plugin/LocoPlugin.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/plugin/LocoPlugin.kt
@@ -12,7 +12,16 @@ class LocoPlugin : Plugin<Project> {
         )
         val configListProvider = project.providers.provider { locoExtension.configList }
 
-        project.tasks.register(LocoTask.NAME, LocoTask::class.java) { task ->
+        project.tasks.register(LocoFetchTask.NAME, LocoFetchTask::class.java) { task ->
+            task.configList.set(configListProvider)
+        }
+
+        project.tasks.register("updateLoco", LocoFetchTask::class.java) { task ->
+            task.configList.set(configListProvider)
+            task.description = "Deprecated: use locoFetch instead."
+        }
+
+        project.tasks.register(LocoPushTask.NAME, LocoPushTask::class.java) { task ->
             task.configList.set(configListProvider)
         }
     }

--- a/lib/src/main/kotlin/com/appswithlove/loco/plugin/LocoPushTask.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/plugin/LocoPushTask.kt
@@ -1,0 +1,34 @@
+package com.appswithlove.loco.plugin
+
+import com.appswithlove.loco.util.TaskUtils
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+abstract class LocoPushTask : DefaultTask() {
+
+    companion object {
+        const val NAME = "locoPush"
+    }
+
+    @get:Input
+    abstract val configList: ListProperty<LocoConfig>
+
+    @TaskAction
+    fun doLast() {
+        if (configList.get().isEmpty()) {
+            throw GradleException("Could not find any Loco Configs.")
+        }
+
+        configList.get().forEach { config ->
+            TaskUtils.push(config)
+        }
+
+        println()
+        println("--------------------------------------")
+        println("Loco text strings pushed successfully!")
+        println("--------------------------------------")
+    }
+}

--- a/lib/src/main/kotlin/com/appswithlove/loco/util/TaskUtils.kt
+++ b/lib/src/main/kotlin/com/appswithlove/loco/util/TaskUtils.kt
@@ -1,6 +1,7 @@
 package com.appswithlove.loco.util
 
 import com.appswithlove.loco.dto.LocaleDto
+import com.appswithlove.loco.dto.PushResultDto
 import com.appswithlove.loco.http.DefaultLocoHttpClient
 import com.appswithlove.loco.http.LocoHttpClient
 import com.appswithlove.loco.plugin.LocoConfig
@@ -82,6 +83,59 @@ object TaskUtils {
             }
         } else {
             throw GradleException("Can't fetch languages. API key is missing in Loco config.")
+        }
+    }
+
+    internal fun push(
+        locoConfig: LocoConfig,
+        httpClient: LocoHttpClient = DefaultLocoHttpClient(),
+    ) {
+        val apiKey = locoConfig.apiKey ?: throw GradleException("apiKey is missing in Loco config.")
+        val resDir = locoConfig.resDir ?: throw GradleException("resDir is missing in Loco config.")
+
+        val locales: List<String> = locoConfig.lang?.takeIf { it.isNotEmpty() } ?: run {
+            println(
+                "Languages not specified in Loco config. Fetching all languages from the project."
+            )
+            fetchAllLanguages(httpClient, apiKey)
+        }
+
+        val json = Json { ignoreUnknownKeys = true }
+
+        for (langEntry in locales) {
+            val androidLang = if (langEntry.contains("-")) {
+                langEntry.replace("-", "-r")
+            } else {
+                langEntry
+            }
+            val folderSuffix = if (langEntry == locoConfig.defLang) "" else "-$androidLang"
+            val file = File("$resDir/values$folderSuffix/${locoConfig.fileName}.xml")
+
+            if (!file.exists()) {
+                println("Skipping $langEntry: file not found at ${file.path}")
+                continue
+            }
+
+            var xmlContent = file.readText(Charsets.UTF_8)
+
+            locoConfig.resourceNamePrefix?.let { prefix ->
+                xmlContent = xmlContent
+                    .replace("<string name=\"$prefix", "<string name=\"")
+                    .replace("<plurals name=\"$prefix", "<plurals name=\"")
+            }
+
+            val response = httpClient.pushTranslation(
+                apiKey = apiKey,
+                locale = langEntry,
+                xmlContent = xmlContent,
+                importBaseUrl = locoConfig.locoImportBaseUrl,
+            )
+            val result = json.decodeFromString<PushResultDto>(response)
+            val progress = result.locales.firstOrNull()?.progress
+            val total = (progress?.translated ?: 0) + (progress?.untranslated ?: 0)
+            println(
+                "[$langEntry] ${result.message} (translated: ${progress?.translated ?: 0}/$total)"
+            )
         }
     }
 

--- a/lib/src/test/kotlin/com/appswithlove/loco/http/FakeLocoHttpClient.kt
+++ b/lib/src/test/kotlin/com/appswithlove/loco/http/FakeLocoHttpClient.kt
@@ -6,6 +6,10 @@ import java.io.IOException
 internal class FakeLocoHttpClient : LocoHttpClient {
     var localesResponse: String = "[]"
     var translationResponses: MutableMap<String, String> = mutableMapOf()
+    var pushTranslationResponse: String =
+        """{"message":"3 assets imported","locales":[{"progress":{"translated":3,"untranslated":0}}]}"""
+    val capturedPushLocales: MutableList<String> = mutableListOf()
+    val capturedPushBodies: MutableList<String> = mutableListOf()
     var shouldFail = false
     var failureException: Exception = IOException("Fake network error")
 
@@ -17,5 +21,17 @@ internal class FakeLocoHttpClient : LocoHttpClient {
     override fun fetchTranslation(locoConfig: LocoConfig, language: String): String {
         if (shouldFail) throw failureException
         return translationResponses[language] ?: "<resources></resources>"
+    }
+
+    override fun pushTranslation(
+        apiKey: String,
+        locale: String,
+        xmlContent: String,
+        importBaseUrl: String,
+    ): String {
+        if (shouldFail) throw failureException
+        capturedPushLocales.add(locale)
+        capturedPushBodies.add(xmlContent)
+        return pushTranslationResponse
     }
 }

--- a/lib/src/test/kotlin/com/appswithlove/loco/util/TaskUtilsTest.kt
+++ b/lib/src/test/kotlin/com/appswithlove/loco/util/TaskUtilsTest.kt
@@ -196,4 +196,96 @@ class TaskUtilsTest {
         File(tempDir, "values/strings.xml").exists() shouldBe true
         File(tempDir, "values-de/strings.xml").exists() shouldBe true
     }
+
+    @Test
+    fun push_withValidConfig_pushesXmlForEachLocale() {
+        File(tempDir, "values").mkdirs()
+        File(tempDir, "values/strings.xml").writeText("<resources><string name=\"hello\">Hello</string></resources>")
+
+        TaskUtils.push(config(), fake)
+
+        fake.capturedPushLocales shouldBe listOf("en")
+    }
+
+    @Test
+    fun push_withMultipleLocales_pushesEachFile() {
+        File(tempDir, "values").mkdirs()
+        File(tempDir, "values-de").mkdirs()
+        File(tempDir, "values/strings.xml").writeText("<resources></resources>")
+        File(tempDir, "values-de/strings.xml").writeText("<resources></resources>")
+
+        TaskUtils.push(config { lang = listOf("en", "de") }, fake)
+
+        fake.capturedPushLocales shouldContainExactlyInAnyOrder listOf("en", "de")
+    }
+
+    @Test
+    fun push_withResourceNamePrefix_stripsPrefix() {
+        File(tempDir, "values").mkdirs()
+        File(tempDir, "values/strings.xml").writeText(
+            """<resources><string name="app_hello">Hello</string><plurals name="app_items"></plurals></resources>"""
+        )
+
+        TaskUtils.push(config { resourceNamePrefix = "app_" }, fake)
+
+        fake.capturedPushBodies[0] shouldContain "\"hello\""
+        fake.capturedPushBodies[0] shouldNotContain "\"app_hello\""
+        fake.capturedPushBodies[0] shouldContain "\"items\""
+        fake.capturedPushBodies[0] shouldNotContain "\"app_items\""
+    }
+
+    @Test
+    fun push_withNullApiKey_throwsGradleException() {
+        shouldThrow<GradleException> {
+            TaskUtils.push(LocoConfig().apply { resDir = tempDir.absolutePath }, fake)
+        }
+    }
+
+    @Test
+    fun push_withNullResDir_throwsGradleException() {
+        shouldThrow<GradleException> {
+            TaskUtils.push(LocoConfig().apply { apiKey = "key" }, fake)
+        }
+    }
+
+    @Test
+    fun push_whenFileNotFound_skipsLocale() {
+        TaskUtils.push(config(), fake)
+
+        fake.capturedPushLocales shouldBe emptyList()
+    }
+
+    @Test
+    fun push_withRegionalLocale_resolvesCorrectFolder() {
+        File(tempDir, "values-es-rMX").mkdirs()
+        File(tempDir, "values-es-rMX/strings.xml").writeText("<resources></resources>")
+
+        TaskUtils.push(config { lang = listOf("es-MX") }, fake)
+
+        fake.capturedPushLocales shouldBe listOf("es-MX")
+    }
+
+    @Test
+    fun push_withNullLang_fetchesLocalesFromApiThenPushes() {
+        fake.localesResponse = """[{"code":"en"},{"code":"de"}]"""
+        File(tempDir, "values").mkdirs()
+        File(tempDir, "values-de").mkdirs()
+        File(tempDir, "values/strings.xml").writeText("<resources></resources>")
+        File(tempDir, "values-de/strings.xml").writeText("<resources></resources>")
+
+        TaskUtils.push(config { lang = null }, fake)
+
+        fake.capturedPushLocales shouldContainExactlyInAnyOrder listOf("en", "de")
+    }
+
+    @Test
+    fun push_withNetworkError_propagatesException() {
+        File(tempDir, "values").mkdirs()
+        File(tempDir, "values/strings.xml").writeText("<resources></resources>")
+        fake.shouldFail = true
+
+        shouldThrow<Exception> {
+            TaskUtils.push(config(), fake)
+        }
+    }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
 
 Loco {
     config {
-        apiKey = "Rp7NhLA0OpPQz8fKdnkXusl4dAR6xMLpZ"
+        apiKey = "OMSeWPoUt_G_4SuFP-md4A0tc5AS5byx"
         lang = listOf("en", "de")
         defLang = "en"
         fallbackLang = "en"

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
 
 Loco {
     config {
-        apiKey = "LBsleEFqO2zZeYaxU_d7pB8v4XBralr1"
+        apiKey = "Rp7NhLA0OpPQz8fKdnkXusl4dAR6xMLpZ"
         lang = listOf("en", "de")
         defLang = "en"
         fallbackLang = "en"


### PR DESCRIPTION
Adds a locoPush Gradle task that reads local strings.xml files and imports them into the Loco project - creating new assets without deleting anything from Loco

- `locoFetch` replaces `updateLoco` (kept as deprecated alias)
- `locoPush` posts each configured locale's XML to the Loco import API
- When `lang` is not configured, locales are fetched from the Loco API automatically